### PR TITLE
fix bug when a model has a tags field but not named tags,for example …

### DIFF
--- a/taggit_serializer/serializers.py
+++ b/taggit_serializer/serializers.py
@@ -33,7 +33,7 @@ class TaggitSerializer(serializers.Serializer):
             for tag in tag_values:
                 getattr(tag_object, key).add(tag)
 
-            for tag in tag_object.tags.names():
+            for tag in getattr(tag_object, key).names():
                 if tag not in tag_values:
                     getattr(tag_object, key).remove(tag)
 


### PR DESCRIPTION
fix bug when a model has a tags field but not named tags,for example name 'labels', it will fail .

my env is centos6.2
