### PR TITLE
Trim tag names

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ class YourSerializer(TaggitSerializer, serializers.ModelSerializer):
 
 And you're done, so now you can add tags to your model
 
+Please note that `TagListSerializerField` strips leading/trailing whitespace from tag names by default.
+
+To prevent this, use the kwarg `trim_whitespace=False` upon instantiation:
+```python
+tags = TagListSerializerField(trim_whitespace=False)
+```
+
 ## Contribute
 
 Please feel free to create pull requests and issues!

--- a/taggit_serializer/serializers.py
+++ b/taggit_serializer/serializers.py
@@ -44,6 +44,7 @@ class TagListSerializerField(serializers.Field):
 
     def __init__(self, **kwargs):
         pretty_print = kwargs.pop("pretty_print", True)
+        trim_whitespace = kwargs.pop("trim_whitespace", True)
 
         style = kwargs.pop("style", {})
         kwargs["style"] = {'base_template': 'textarea.html'}
@@ -52,6 +53,7 @@ class TagListSerializerField(serializers.Field):
         super(TagListSerializerField, self).__init__(**kwargs)
 
         self.pretty_print = pretty_print
+        self.trim_whitespace = trim_whitespace
 
     def to_internal_value(self, value):
         if isinstance(value, six.string_types):
@@ -70,6 +72,9 @@ class TagListSerializerField(serializers.Field):
                 self.fail('not_a_str')
 
             self.child.run_validation(s)
+
+        if self.trim_whitespace:
+            value = [s.strip() for s in value]
 
         return value
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -34,6 +34,18 @@ class TestTaggit_serializer(unittest.TestCase):
         except ValidationError:
             pass
 
+    def test_taggit_serializer_field_trim_whitespace(self):
+        tags = ["a", "   b   "]
+        serializer_field = serializers.TagListSerializerField()
+        value = serializer_field.to_internal_value(tags)
+        assert "a" in value
+        assert "b" in value
+
+        serializer_field = serializers.TagListSerializerField(trim_whitespace=False)
+        value = serializer_field.to_internal_value(tags)
+        assert "a" in value
+        assert "   b   " in value
+
     def test_taggit_serializer_update(self):
         """ Test if serializer class is working properly on updating object """
         request_data = {


### PR DESCRIPTION
Hi,

this PR implements leading/trailing whitespace trimming of tag names in TagListSerializerField.
This prevents issues with databases that ignore trailing whitespaces during comparisons (i.e. MySQL 5.x).
Please note that my implementation changes the current default behaviour in this regard.
Let me know if I need to change anything.

Thanks for your work on this library!
