### PR TITLE
Fix error in object update

### DIFF
--- a/taggit_serializer/serializers.py
+++ b/taggit_serializer/serializers.py
@@ -105,7 +105,8 @@ class TaggitSerializer(serializers.Serializer):
     def _save_tags(self, tag_object, tags):
         for key in tags.keys():
             tag_values = tags.get(key)
-            getattr(tag_object, key).set(*tag_values)
+            model = tag_object._meta.model
+            model.objects.get(id=tag_object.id).tags.set(*tag_values)
 
         return tag_object
 


### PR DESCRIPTION
Fix 'list' object has no attribute 'set' in `_save_tags(self, tag_object, tags)`.

This code getattr(tag_object, key) inside "_save_tags" method is returning a list instead of a TaggableManager class.

def _save_tags(self, tag_object, tags):
    for key in tags.keys():
        tag_values = tags.get(key)
        getattr(tag_object, key).set(*tag_values)
    return tag_object

It happens during update object with tags.