### PR TITLE
Add max_length validation for child CharField

### DIFF
--- a/taggit_serializer/serializers.py
+++ b/taggit_serializer/serializers.py
@@ -32,7 +32,7 @@ class TagList(list):
 
 
 class TagListSerializerField(serializers.Field):
-    child = serializers.CharField()
+    child = serializers.CharField(max_length=100)
     default_error_messages = {
         'not_a_list': _(
             'Expected a list of items but got type "{input_type}".'),


### PR DESCRIPTION
If this validator is not used, a django.db.utils.DataError
is thrown for values longer than 100 characters.
This results in a HTTP 500 serverside Error instead of a HTTP 400.