### PR TITLE
Fix incompability with django-taggit 2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,16 @@ language: python
 sudo: false
 
 python:
+  - "3.10"
+  - "3.9"
+  - "3.8"
+  - "3.7"
   - "3.6"
-  - "3.5"
-  - "2.7"
 
 env:
-  - DJANGO_REST_VERSION=3.8.0 DJANGO_VERSION=">=2.0"
-  - DJANGO_REST_VERSION=3.7.7 DJANGO_VERSION="<2.0"
-  - DJANGO_REST_VERSION=3.3.3 DJANGO_VERSION="<1.11"
-  - DJANGO_REST_VERSION=3.2.5 DJANGO_VERSION="<=1.9"
-  - DJANGO_REST_VERSION=3.1.3 DJANGO_VERSION="<=1.8"
-
-matrix:
-  exclude:
-     - python: "2.7"
-       env: DJANGO_REST_VERSION=3.8.0 DJANGO_VERSION=">=2.0"
+  - DJANGO_REST_VERSION=3.8.0 DJANGO_VERSION="==2.2"
+  - DJANGO_REST_VERSION=3.9.3 DJANGO_VERSION="==3.2"
+  - DJANGO_REST_VERSION=3.12.4 DJANGO_VERSION="==4.0"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 sudo: false
 
 python:
-  - "3.10"
   - "3.9"
   - "3.8"
   - "3.7"
@@ -13,7 +12,7 @@ python:
 env:
   - DJANGO_REST_VERSION=3.8.0 DJANGO_VERSION="==2.2"
   - DJANGO_REST_VERSION=3.9.3 DJANGO_VERSION="==3.2"
-  - DJANGO_REST_VERSION=3.12.4 DJANGO_VERSION="==4.0"
+  - DJANGO_REST_VERSION=3.12.4 DJANGO_VERSION=">=4.0"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -43,7 +43,7 @@ articles, and such.
 Submit Feedback
 ~~~~~~~~~~~~~~~
 
-The best way to send feedback is to file an issue at https://github.com/glemmaPaul/django-taggit-serializer/issues.
+The best way to send feedback is to file an issue at https://github.com/adriangzz/dj-taggit-serializer/issues.
 
 If you are proposing a feature:
 
@@ -55,17 +55,17 @@ If you are proposing a feature:
 Get Started!
 ------------
 
-Ready to contribute? Here's how to set up `django-taggit-serializer` for local development.
+Ready to contribute? Here's how to set up `dj-taggit-serializer` for local development.
 
-1. Fork the `django-taggit-serializer` repo on GitHub.
+1. Fork the `dj-taggit-serializer` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/django-taggit-serializer.git
+    $ git clone git@github.com:your_name_here/dj-taggit-serializer.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed, this is how you set up your fork for local development::
 
-    $ mkvirtualenv django-taggit-serializer
-    $ cd django-taggit-serializer/
+    $ mkvirtualenv dj-taggit-serializer
+    $ cd dj-taggit-serializer/
     $ python setup.py develop
 
 4. Create a branch for local development::

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ Types of Contributions
 Report Bugs
 ~~~~~~~~~~~
 
-Report bugs at https://github.com/glemmaPaul/django-taggit-serializer/issues.
+Report bugs at https://github.com/adriangzz/dj-taggit-serializer/issues.
 
 If you are reporting a bug, please include:
 
@@ -101,7 +101,7 @@ Before you submit a pull request, check that it meets these guidelines:
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
 3. The pull request should work for Python 2.6, 2.7, and 3.3, and for PyPy. Check 
-   https://travis-ci.org/glemmaPaul/django-taggit-serializer/pull_requests
+   https://app.travis-ci.com/adriangzz/dj-taggit-serializer/pull_requests
    and make sure that the tests pass for all supported Python versions.
 
 Tips

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ clean-pyc:
 	find . -name '*~' -exec rm -f {} +
 
 lint:
-	flake8 django-taggit-serializer tests
+	flake8 dj-taggit-serializer tests
 
 test:
 	python runtests.py test
@@ -33,15 +33,15 @@ test-all:
 	tox
 
 coverage:
-	coverage run --source django-taggit-serializer setup.py test
+	coverage run --source dj-taggit-serializer setup.py test
 	coverage report -m
 	coverage html
 	open htmlcov/index.html
 
 docs:
-	rm -f docs/django-taggit-serializer.rst
+	rm -f docs/dj-taggit-serializer.rst
 	rm -f docs/modules.rst
-	sphinx-apidoc -o docs/ django-taggit-serializer
+	sphinx-apidoc -o docs/ dj-taggit-serializer
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	open docs/_build/html/index.html

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The `django-taggit` package makes it possible to tag a certain module.
 To install this package you can use the following `pip` installation:
 
 ```
-pip install django-taggit-serializer
+pip install dj-taggit-serializer
 ```
 
 Then, add `taggit_serializer` to your `Settings` in `INSTALLED_APPS`:

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Django Taggit Rest Serializer
 
-[![Build Status](https://travis-ci.org/glemmaPaul/django-taggit-serializer.svg?branch=master)](https://travis-ci.org/glemmaPaul/django-taggit-serializer)
+[![Build Status](https://app.travis-ci.com/adriangzz/dj-taggit-serializer.svg?branch=master)](https://app.travis-ci.com/github/adriangzz/dj-taggit-serializer)
 
 ## About
+
 This package is meant for the `django-taggit` package which is available [here](https://github.com/alex/django-taggit)
 
 The `django-taggit` package makes it possible to tag a certain module.
 
 ## Installation
+
 To install this package you can use the following `pip` installation:
+
 ```
 pip install django-taggit-serializer
 ```
 
 Then, add `taggit_serializer` to your `Settings` in `INSTALLED_APPS`:
+
 ```
     INSTALLED_APS = (
         ...
@@ -22,9 +26,11 @@ Then, add `taggit_serializer` to your `Settings` in `INSTALLED_APPS`:
 ```
 
 ## Usage
+
 Because the tags in `django-taggit` need to be added into a `TaggableManager()` we cannot use the usual `Serializer` that we get from Django REST Framework. Because this is trying to save the tags into a `list`, which will throw an exception.
 
 To accept tags through a `REST` API call we need to add the following to our `Serializer`:
+
 ```python
 from taggit_serializer.serializers import (TagListSerializerField,
                                            TaggitSerializer)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -173,7 +173,7 @@ html_static_path = ['_static']
 #html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'django-taggit-serializerdoc'
+htmlhelp_basename = 'dj-taggit-serializerdoc'
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -192,7 +192,7 @@ latex_elements = {
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'django-taggit-serializer.tex', u'taggit_serializer Documentation',
+  ('index', 'dj-taggit-serializer.tex', u'taggit_serializer Documentation',
    u'Paul Oostenrijk', 'manual'),
 ]
 
@@ -222,7 +222,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'django-taggit-serializer', u'taggit_serializer Documentation',
+    ('index', 'dj-taggit-serializer', u'taggit_serializer Documentation',
      [u'Paul Oostenrijk'], 1)
 ]
 
@@ -236,8 +236,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'django-taggit-serializer', u'taggit_serializer Documentation',
-   u'Paul Oostenrijk', 'django-taggit-serializer', 'One line description of project.',
+  ('index', 'dj-taggit-serializer', u'taggit_serializer Documentation',
+   u'Paul Oostenrijk', 'dj-taggit-serializer', 'One line description of project.',
    'Miscellaneous'),
 ]
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,9 +4,9 @@ Installation
 
 At the command line::
 
-    $ easy_install django-taggit-serializer
+    $ easy_install dj-taggit-serializer
 
 Or, if you have virtualenvwrapper installed::
 
-    $ mkvirtualenv django-taggit-serializer
-    $ pip install django-taggit-serializer
+    $ mkvirtualenv dj-taggit-serializer
+    $ pip install dj-taggit-serializer

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -4,4 +4,4 @@ Usage
 
 To use taggit_serializer in a project::
 
-    import django-taggit-serializer
+    import dj-taggit-serializer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-django>=1.8
+django>=2.2
 wheel==0.24.0
 # Additional requirements go here
-django-taggit>=0.22.2
+django-taggit>=1.2.0
 six

--- a/setup.py
+++ b/setup.py
@@ -22,16 +22,16 @@ if sys.argv[-1] == 'publish':
 
 
 setup(
-    name='django-taggit-serializer',
+    name='dj-taggit-serializer',
     version=version,
     description="""The Django Taggit serializer for tDjango REST Framework""",
     long_description="The Django Taggit Serializer for the Django"
                      "REST Framework developers. "
                      "Installation can be found on "
                      "https://github.com/glemmaPaul/django-taggit-serializer",
-    author='Paul Oostenrijk',
-    author_email='paul@glemma.nl',
-    url='https://github.com/glemmaPaul/django-taggit-serializer',
+    author='Paul Oostenrijk, Adrian Gonzalez',
+    author_email='paul@glemma.nl, adriangonzalezmontemayor@gmail.com',
+    url='https://github.com/adriangzz/dj-taggit-serializer',
     packages=[
         'taggit_serializer',
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ if sys.argv[-1] == 'publish':
 setup(
     name='dj-taggit-serializer',
     version=version,
-    description="""The Django Taggit serializer for tDjango REST Framework""",
+    description="""The Django Taggit serializer for Django REST Framework""",
     long_description="The Django Taggit Serializer for the Django"
                      "REST Framework developers. "
                      "Installation can be found on "

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description="The Django Taggit Serializer for the Django"
                      "REST Framework developers. "
                      "Installation can be found on "
-                     "https://github.com/glemmaPaul/django-taggit-serializer",
+                     "https://github.com/adriangzz/dj-taggit-serializer",
     author='Paul Oostenrijk, Adrian Gonzalez',
     author_email='paul@glemma.nl, adriangonzalezmontemayor@gmail.com',
     url='https://github.com/adriangzz/dj-taggit-serializer',
@@ -41,7 +41,7 @@ setup(
     ],
     license="BSD",
     zip_safe=False,
-    keywords='django-taggit-serializer',
+    keywords='dj-taggit-serializer',
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Framework :: Django',

--- a/taggit_serializer/serializers.py
+++ b/taggit_serializer/serializers.py
@@ -105,7 +105,7 @@ class TaggitSerializer(serializers.Serializer):
     def _save_tags(self, tag_object, tags):
         for key in tags.keys():
             tag_values = tags.get(key)
-            getattr(tag_object, key).set(*tag_values)
+            getattr(tag_object, key).set(tag_values)
 
         return tag_object
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -2,10 +2,10 @@
 # -*- coding: utf-8 -*-
 
 """
-test_django-taggit-serializer
+test_dj-taggit-serializer
 ------------
 
-Tests for `django-taggit-serializer` models module.
+Tests for `dj-taggit-serializer` models module.
 """
 
 import unittest


### PR DESCRIPTION
Fixes the issue #53 caused by a [breaking change](https://github.com/jazzband/django-taggit/blob/master/CHANGELOG.rst#200-2021-11-14) in django-taggit 2.0.0 where `set` now takes a list instead of varargs. 
