### PR TITLE
Update Serializer to allow Django 4.0 support

### DIFF
--- a/taggit_serializer/serializers.py
+++ b/taggit_serializer/serializers.py
@@ -3,7 +3,7 @@ import json
 
 # Third party
 import six
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from rest_framework import serializers
 
 


### PR DESCRIPTION
Django 4.0 has deprecated `ugettext_lazy` in favor of `gettext_lazy`

```
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().
```